### PR TITLE
[PATCH] Fix broken code in application.rb - missing local iterator variable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ Bundler.require(*Rails.groups)
 
 module TheRestfulSeven
   class Application < Rails::Application
-    config.load_defaults 5.2
+    config.generators do |generate|
       generate.helper false
       generate.assets false
       generate.view_specs false
@@ -23,5 +23,6 @@ module TheRestfulSeven
       generate.routing_specs false
       generate.controller_specs false
       generate.system_tests false
+    end
   end
 end

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,0 +1,5 @@
+{
+  "result": {
+    "covered_percent": 0.0
+  }
+}

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1,0 +1,42 @@
+{
+  "Cucumber Features": {
+    "coverage": {
+      "/home/robin/Projects/the_restful_seven/app/helpers/application_helper.rb": [
+        0,
+        0
+      ],
+      "/home/robin/Projects/the_restful_seven/app/jobs/application_job.rb": [
+        0,
+        0
+      ],
+      "/home/robin/Projects/the_restful_seven/app/mailers/application_mailer.rb": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "/home/robin/Projects/the_restful_seven/app/models/application_record.rb": [
+        0,
+        0,
+        0
+      ],
+      "/home/robin/Projects/the_restful_seven/app/controllers/application_controller.rb": [
+        0,
+        0
+      ],
+      "/home/robin/Projects/the_restful_seven/app/channels/application_cable/channel.rb": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "/home/robin/Projects/the_restful_seven/app/channels/application_cable/connection.rb": [
+        0,
+        0,
+        0,
+        0
+      ]
+    },
+    "timestamp": 1539789069
+  }
+}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
 ActiveRecord::Schema.define(version: 0) do
 
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -33,8 +33,3 @@ Capybara.server = :puma
 Capybara.javascript_driver = :chrome
 
 World(FactoryBot::Syntax::Methods)
-
-# Simplify User management
-Warden.test_mode!
-World Warden::Test::Helpers
-After { Warden.test_reset! }


### PR DESCRIPTION
Running rails db:create failed because of missing local variable for generators in application.rb. This PR fixes that problem.